### PR TITLE
garnet: sepolicy: Label more wakeup nodes

### DIFF
--- a/sepolicy/vendor/genfs_contexts
+++ b/sepolicy/vendor/genfs_contexts
@@ -18,3 +18,4 @@ genfscon sysfs /devices/platform/soc/a94000.qcom,qup_uart/wakeup u:object_r:sysf
 genfscon sysfs /devices/platform/soc/c42d000.qcom,spmi/spmi-0/0-00/c42d000.qcom,spmi:qcom,pmk8350@0:pon_hlos@1300/c42d000.qcom,spmi:qcom,pmk8350@0:pon_hlos@1300:pwrkey-bark/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/c42d000.qcom,spmi/spmi-0/0-00/c42d000.qcom,spmi:qcom,pmk8350@0:pon_hlos@1300/c42d000.qcom,spmi:qcom,pmk8350@0:pon_hlos@1300:pwrkey-resin-bark/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:fingerprint_goodix/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/a80000.i2c/i2c-3/3-0028/wakeup u:object_r:sysfs_wakeup:s0


### PR DESCRIPTION
Fix some sysfs_wakeup node

> E android.system.suspend-service: Error opening kernel wakelock stats for: wakeup20 (../../devices/platform/soc/a80000.i2c/i2c-3/3-0028/wakeup/wakeup20): Permission denied